### PR TITLE
Now allowing php 7.x to be used.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0"
+        "php": "~5.5.0|~5.6.0|^7.0.0"
     },
     "type": "magento2-module",
     "autoload": {


### PR DESCRIPTION
there is no real reason, why php 7.1 or 7.2 should not be able to be used with your plugin, so here's the change to handle it